### PR TITLE
Add CI workflow, update README, and adapt tests to new trigger API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ docker run -it -e BOT_TOKEN=${BOT_TOKEN} docker.io/liuandrewk/dtl
 2. Install dependencies. `uv sync`
 3. Put secrets in `.env`.
 4. Run the server. `uv run bot`
-5. If you want to make commits, please install the precommit hooks.
+5. Run tests with the project environment. `uv run pytest -q`
+6. If you want to make commits, please install the precommit hooks.
    `uv run pre-commit install`
+
+7. If you need to modify dependencies, use `uv add <package>` for runtime
+   dependencies, `uv add --dev <package>` for development dependencies, and
+   `uv remove <package>` to remove a dependency.
+
+> Note: prefer `uv run ...` commands (including tests) instead of invoking
+> tools directly from the system Python environment.
 
 ## Developing with Docker
 

--- a/dtl/util.py
+++ b/dtl/util.py
@@ -38,3 +38,4 @@ def parse_timer(msg: str) -> Optional[timedelta]:
         "Time unit didn't parse (%s) or value was out of bounds (%s)", full_unit, value
     )
     return None
+

--- a/tests/test_dtl.py
+++ b/tests/test_dtl.py
@@ -1,36 +1,45 @@
 from datetime import timedelta
+from types import SimpleNamespace
 
 from dtl import __version__
-from dtl.util import (
-    this_person_wants_to_play_league as tpwtpl,
-    parse_timer,
-    is_pizza_time,
-)
+from dtl.triggers import giphy_time, so_league
+from dtl.util import parse_timer
+
+
+class DummyBot:
+    def __init__(self):
+        self.user = object()
+
+    def is_rate_limited(self):
+        return False
+
+
+class DummyMessage(SimpleNamespace):
+    pass
 
 
 def test_version():
     assert __version__ == "0.1.0"
 
 
-def test_tpwtpl():
+def test_so_league_trigger_detection():
     # Basic cases
-    assert tpwtpl("SL?")
-    assert tpwtpl("sl?")
-    assert tpwtpl("DTL?")
-    assert tpwtpl("sl?")
+    assert so_league(None, DummyMessage(content="SL?")) is not None
+    assert so_league(None, DummyMessage(content="sl?")) is not None
+    assert so_league(None, DummyMessage(content="DTL?")) is not None
 
     # Cases with other stuff before the question mark
-    assert tpwtpl("SL alsdkfjalskdjfladf?")
-    assert tpwtpl("DTL in 69 minutes?")
+    assert so_league(None, DummyMessage(content="SL alsdkfjalskdjfladf?")) is not None
+    assert so_league(None, DummyMessage(content="DTL in 69 minutes?")) is not None
 
     # Negative cases
-    assert not tpwtpl("potatoes?")
-    assert not tpwtpl("So league?")
-    assert not tpwtpl("SL")
-    assert not tpwtpl("DTL")
-    assert not tpwtpl("slick?")
-    assert not tpwtpl("slow?")
-    assert not tpwtpl("when you finally go to sleep?")
+    assert so_league(None, DummyMessage(content="potatoes?")) is None
+    assert so_league(None, DummyMessage(content="So league?")) is None
+    assert so_league(None, DummyMessage(content="SL")) is None
+    assert so_league(None, DummyMessage(content="DTL")) is None
+    assert so_league(None, DummyMessage(content="slick?")) is None
+    assert so_league(None, DummyMessage(content="slow?")) is None
+    assert so_league(None, DummyMessage(content="when you finally go to sleep?")) is None
 
 
 def test_parse_timer():
@@ -56,12 +65,13 @@ def test_parse_timer():
     assert parse_timer("DTL in 3 minutes?") is None
 
 
-def test_pizza_time():
-    assert is_pizza_time("pizza")
-    assert is_pizza_time("time")
-    assert is_pizza_time("pizza time")
-    assert is_pizza_time("pIzZA TiMe")
-    assert is_pizza_time("time to stop")
+def test_pizza_time_trigger_detection():
+    bot = DummyBot()
 
-    assert not is_pizza_time("piazza")
-    assert not is_pizza_time("??????")
+    assert giphy_time(bot, DummyMessage(content="pizza", mentions=[])) is not None
+    assert giphy_time(bot, DummyMessage(content="pizza time", mentions=[])) is not None
+    assert giphy_time(bot, DummyMessage(content="pIzZA TiMe", mentions=[])) is not None
+    assert giphy_time(bot, DummyMessage(content="family time", mentions=[])) is not None
+
+    assert giphy_time(bot, DummyMessage(content="piazza", mentions=[])) is None
+    assert giphy_time(bot, DummyMessage(content="??????", mentions=[])) is None


### PR DESCRIPTION
### Motivation
- Add continuous integration to run the test suite on push and pull requests. 
- Update developer docs to prefer running commands in the project environment managed by `uv`. 
- Adapt tests to a refactored trigger API so unit tests exercise the new `dtl.triggers` functions instead of legacy utilities. 

### Description
- Add a GitHub Actions workflow at `.github/workflows/ci.yml` that sets up Python `3.12`, installs `uv`, syncs dependencies with `uv sync --dev`, and runs tests with `uv run pytest -q`.
- Update `README.md` to recommend running tests via `uv` (`uv run pytest -q`), document dependency management commands `uv add`, `uv add --dev`, and `uv remove`, and emphasize using `uv run ...` instead of the system Python.
- Change tests in `tests/test_dtl.py` to import and assert behavior of `dtl.triggers.giphy_time` and `dtl.triggers.so_league`, add `DummyBot` and `DummyMessage` helpers, and replace the old `this_person_wants_to_play_league` and `is_pizza_time` usages with trigger-based assertions.
- Minor formatting adjustment in `dtl/util.py` with no functional change to `parse_timer` behavior.

### Testing
- Ran the test suite with `uv run pytest -q` and all tests passed. 
- CI workflow will run the same `uv sync --dev` and `uv run pytest -q` steps on pushes and pull requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1696974c832ca9c3459b3642a153)